### PR TITLE
Fixed an issue with Create button not being shown

### DIFF
--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -6,7 +6,7 @@ import { StoreService } from '../store.service';
 @Component({
   selector: 'Header',
   template: `
-    
+
     <!-- Този back btn се появява само във формата, но това е отвъд моите способности :) -->
     <div class="tl">
       <a class="btn_back" routerLink="/">
@@ -31,14 +31,16 @@ import { StoreService } from '../store.service';
     </div>
     -->
   `,
+  /* `min-height` in addition to `height` fixed an issue with flexbox on Chrome */
   styles: [`
     :host {
       display: grid;
-      grid-template-columns: 1fr 1fr 1fr;
+      grid-template-columns: 1fr 2fr 1fr;
       align-items: center;
       background: var(--neutral-lighter);
       padding: 1rem;
       height: 64px;
+      min-height: 64px;
       text-align: center;
     }
 

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -14,8 +14,9 @@ import { pageTransition } from '../animations';
   `,
   styles: [`
     :host {
-      display: block;
       position: relative;
+      display: flex;
+      flex-direction: column;
     }
 
     .header {
@@ -26,7 +27,6 @@ import { pageTransition } from '../animations';
     .content {
       overflow-x: hidden;
       overflow-y: auto;
-      height: 100%;
     }
   `]
 })


### PR DESCRIPTION
Because we set the content height to 100%, but the header was taking up
some space, the Create button was being cut off in the form. Using
flexbox fixed that, but then the header was not being shown correctly,
so I added a `min-height` there in addition to the height.