### PR TITLE
Hide back button on root level

### DIFF
--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,21 +1,19 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
-import { AuthService } from '../auth.service';
+// import { AuthService } from '../auth.service';
 import { StoreService } from '../store.service';
 
 @Component({
   selector: 'Header',
   template: `
-
-    <!-- Този back btn се появява само във формата, но това е отвъд моите способности :) -->
     <div class="tl">
-      <a class="btn_back" routerLink="/">
-        <img src="assets/ui_icon_back.svg" alt="Върни се в началото" />
+      <a class="backButton" [class.--hidden]="routeLevel === 0" routerLink="/">
+        <img src="assets/ui_icon_back.svg" [alt]="i18n.back" />
       </a>
     </div>
 
-    <a class="logo__link" routerLink="/">
-      <img class="logo__image" src="assets/logo.svg" alt="Отвъд Спорта Лого" />
+    <a class="logo" routerLink="/">
+      <img class="logo__image" src="assets/logo.svg" [alt]="i18n.logo" />
     </a>
 
     <!--
@@ -23,12 +21,6 @@ import { StoreService } from '../store.service';
     <a routerLink="/playgrounds">Игрища</a>
     <a *ngIf="(store.user$ | async) == null" routerLink="/login">Вход</a>
     <a *ngIf="(store.user$ | async) != null" routerLink="/" (click)="logout()">Изход</a>
-    -->
-
-    <!--
-    <div class="toggle border-primary br-md pointer" (click)="showSidebarChange.emit(!showSidebar)">
-      <img class="toggle__image" [src]="showSidebar ? 'assets/chevron-up.svg' : 'assets/chevron-down.svg'" />
-    </div>
     -->
   `,
   /* `min-height` in addition to `height` fixed an issue with flexbox on Chrome */
@@ -44,60 +36,52 @@ import { StoreService } from '../store.service';
       text-align: center;
     }
 
-    .btn_back {
-      background-color: rgba(0,100,177,0.10);
+    .backButton {
       border-radius: 100%;
-      display: inline-block;
+      display: flex;
       width: 32px;
       height: 32px;
       line-height: 32px;
       padding: 0 10px;
-      transition: background-color 0.2s ease-in-out;
-    }
-    .btn_back:hover {
-      background-color: rgba(0,100,177,0.20);
+
+      transition: all var(--transition-duration) var(--transition-easing);
+      transition-property: background, opacity;
+      background: rgba(0, 100, 177, 0.10);
+      opacity: 1;
     }
 
-    .logo__link {
+    .backButton:hover {
+      background: rgba(0, 100, 177, 0.20);
+    }
+
+    .backButton.--hidden {
+      opacity: 0;
+    }
+
+    .logo {
       grid-column: 2;
     }
 
-    .logo__link img {
+    .logo__image {
       width: 32px;
-    }
-
-    .toggle {
-      user-select: none;
-      box-shadow: var(--box-shadow);
-      width: 2rem;
-      height: 2rem;
-      line-height: 2rem;
-      text-align: center;
-
-      transition: background var(--transition-duration) var(--transition-easing);
-    }
-
-    .toggle:hover {
-      background: rgba(0, 0, 0, 0.02);
-    }
-
-    .toggle__image {
-      width: 1rem;
-      height: 1rem;
     }
   `]
 })
 export class HeaderComponent {
   constructor(
-    private authService: AuthService,
+    // private authService: AuthService,
     public store: StoreService,
   ) {
   }
 
-  @Input() showSidebar: boolean;
-  @Output() showSidebarChange = new EventEmitter<boolean>();
+  @Input() routeLevel: number;
 
-  logout() {
-    return this.authService.logout();
-  }
+  i18n = {
+    back: 'Върни се в началото',
+    logo: 'Отвъд Спорта',
+  };
+
+  // logout() {
+  //   return this.authService.logout();
+  // }
 }

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -7,7 +7,7 @@ import { pageTransition } from '../animations';
   selector: 'Sidebar',
   animations: [pageTransition],
   template: `
-    <Header class="header sticky top-0"></Header>
+    <Header class="header sticky top-0" [routeLevel]="getRouteLevel(routerOutlet)"></Header>
     <div class="content" [@pageTransition]="getRouteLevel(routerOutlet)">
       <router-outlet #routerOutlet="outlet"></router-outlet>
     </div>


### PR DESCRIPTION
# Done
- [x] Hide header back button on root level (with transition)
- [x] Cleaned up leftover toggle button and classes
- [x] Commented out auth service and logout method

## Level 0
![level-0](https://user-images.githubusercontent.com/1333274/34175647-d90f52b4-e505-11e7-943a-89e22dc1e6f4.png)

## Level 1
![level-1](https://user-images.githubusercontent.com/1333274/34175649-da8db162-e505-11e7-8ea0-124c3d4b02e3.png)
